### PR TITLE
feat: Basic GraphQL support (#4)

### DIFF
--- a/src/Fieldtypes/Address.php
+++ b/src/Fieldtypes/Address.php
@@ -4,6 +4,8 @@ namespace Mattrothenberg\StatamicMapboxAddress\Fieldtypes;
 
 use Statamic\Facades\Antlers;
 use Statamic\Fields\Fieldtype;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Types\ArrayType;
 
 class Address extends Fieldtype
 {
@@ -89,5 +91,15 @@ class Address extends Fieldtype
     public function process($data)
     {
         return $data;
+    }
+
+    /**
+     * Get the GraphQL type that should be used for processing
+     *
+     * @return \GraphQL\Type\Definition\Type
+     */
+    public function toGqlType()
+    {
+        return GraphQL::type(ArrayType::NAME);
     }
 }


### PR DESCRIPTION
Very basic implementation of GraphQL support for the Address fieldtype.

Without these changes, GraphQL throws an Exception because it tries casting the Address field to String.
I've simply made it convert to array instead of string, dumping all the available data from the Address field in an array.