### PR TITLE
Statamic 4 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 vendor
 yarn-error.log
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "require": {
     "php": "^7.3|^8.0",
-    "statamic/cms": "^3.0",
+    "statamic/cms": "^3.0|^4.0",
     "pixelfear/composer-dist-plugin": "^0.1"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
         "Mattrothenberg\\StatamicMapboxAddress\\ServiceProvider"
       ]
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "pixelfear/composer-dist-plugin": true
+    }
   }
 }


### PR DESCRIPTION
Hello 👋

Statamic 4 is due out any day now (in fact the [first beta release](https://github.com/statamic/cms/releases/tag/v4.0.0-beta.1) was tagged yesterday). This pull request adds Statamic 4 compatibility to this addon.

Changes:

* Added `pixelfear/composer-dist-plugin` to the plugin allow list (which is a Composer 2 thing)
* Added `composer.lock` to your `.gitignore` file
    * I noticed you haven't committed one but when I ran `composer install` locally one was generated and showing up in GitHub Desktop, so I've gone ahead and ignored it for you (which is best practise for addons).
* Added the `^4.0` version constraint to the `statamic/cms` dependency. 
    * Feel free to remove `^3.0` if you want to release a v4 only release.

Let me know if you want me to make any changes!